### PR TITLE
feat: Search page 검색어 가져오기

### DIFF
--- a/src/_lib/fetcher.ts
+++ b/src/_lib/fetcher.ts
@@ -9,6 +9,7 @@ interface IFetchOptions {
 
 interface IGetOptions {
   endpoint: string;
+  authorization?: string;
 }
 
 interface IPostOptions {
@@ -51,8 +52,8 @@ const _fetch = async ({ method, endpoint, body, authorization }: IFetchOptions) 
   }
 };
 
-const _get = async ({ endpoint }: IGetOptions) => {
-  return _fetch({ method: "GET", endpoint });
+const _get = async ({ endpoint, authorization }: IGetOptions) => {
+  return _fetch({ method: "GET", endpoint, authorization });
 };
 
 const _post = async ({ endpoint, body, authorization }: IPostOptions) => {

--- a/src/_lib/fetcher.ts
+++ b/src/_lib/fetcher.ts
@@ -60,9 +60,14 @@ const _post = async ({ endpoint, body, authorization }: IPostOptions) => {
   return _fetch({ method: "POST", endpoint, body, authorization });
 };
 
+const _patch = async ({ endpoint, body, authorization }: IPostOptions) => {
+  return _fetch({ method: "PATCH", endpoint, body, authorization });
+};
+
 const api = {
   get: _get,
   post: _post,
+  patch: _patch,
 };
 
 export default api;

--- a/src/app/_component/input/Search_Input.tsx
+++ b/src/app/_component/input/Search_Input.tsx
@@ -1,9 +1,18 @@
 import styles from "./search_input.module.css";
 
-export default function Search_Input() {
+interface ISearchInput {
+    handleEnter: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}
+
+export default function Search_Input({handleEnter}:ISearchInput) {
     return(
         <div className={styles.container}>
-            <input className={styles.input} type="text" placeholder="20글자까지 작성할 수 있어요!"></input>
+            <input 
+                className={styles.input} 
+                type="text" 
+                name="최근검색어"
+                onKeyDown={handleEnter}
+                placeholder="20글자까지 작성할 수 있어요!" />
         </div>
     );
 }

--- a/src/app/api/deleteRecent.ts
+++ b/src/app/api/deleteRecent.ts
@@ -1,0 +1,6 @@
+import api from "@/_lib/fetcher";
+
+export default async function DeleteRecentSearch(token:string) {
+    const data = await api.patch({endpoint:`userSearch/recent`, authorization: token});
+    return data;
+}

--- a/src/app/api/getFilter.ts
+++ b/src/app/api/getFilter.ts
@@ -1,0 +1,56 @@
+import api from "@/_lib/fetcher";
+
+export default async function getFilter(
+    type: string,
+    orderType: string,
+    options?: {
+        quickMatch?: boolean;
+        category?: string | null;
+        startDate?: string | null;
+        duration?: string | null;
+        minParticipants?: number;
+        maxParticipants?: number;
+        tendency?: string;
+    },
+) {
+    let endpoint = `study/${type}/filter?orderType=${orderType}`;
+
+    if (options) {
+        const queryParams = new URLSearchParams();
+
+        if (options.quickMatch !== undefined) {
+        queryParams.append("quickMatch", options.quickMatch ? "true" : "false");
+        }
+
+        if (options.category) {
+        queryParams.append("category", options.category);
+        }
+
+        if (options.startDate) {
+        queryParams.append("startDate", options.startDate);
+        }
+
+        if (options.duration !== null && options.duration !== undefined) {
+        queryParams.append("duration", options.duration!.toString());
+        }
+
+        if (options.minParticipants !== undefined) {
+        queryParams.append("minParticipants", options.minParticipants.toString());
+        }
+
+        if (options.maxParticipants !== undefined) {
+        queryParams.append("maxParticipants", options.maxParticipants.toString());
+        }
+
+        if (options.tendency) {
+        queryParams.append("tendency", options.tendency);
+        }
+
+        if (queryParams.toString()) {
+        endpoint += `&${queryParams.toString()}`;
+        }
+    }
+
+    const data = await api.get({ endpoint });
+    return data;
+    }

--- a/src/app/api/popularSearch.ts
+++ b/src/app/api/popularSearch.ts
@@ -1,0 +1,6 @@
+import api from "@/_lib/fetcher";
+
+export default async function GetPopularSearch() {
+    const data = await api.get({endpoint:`userSearch/popular`});
+    return data;
+}

--- a/src/app/api/recentSearch.ts
+++ b/src/app/api/recentSearch.ts
@@ -1,0 +1,6 @@
+import api from "@/_lib/fetcher";
+
+export default async function GetRecentSearch(token:string) {
+    const data = await api.get({endpoint:`userSearch/recent`, authorization: token});
+    return data;
+}

--- a/src/app/api/studyInfo.ts
+++ b/src/app/api/studyInfo.ts
@@ -1,0 +1,6 @@
+import api from "@/_lib/fetcher";
+
+export default async function GetPopularSearch() {
+    const data = await api.get({endpoint:`userSearch/popular`});
+    return data;
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -53,8 +53,7 @@ export default function Main_home() {
       </div>
       <div className={styles.cardBox}>
         <div className={styles.card}>
-          <Card />
-          <Card />
+
         </div>
       </div>
       <div className={styles.footerBox}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import Footer from "./_component/footer/footer";
 import Toggle from "./_component/toggle/toggle";
 import Navigation from "./_component/navigation/page";
 import Guide from "./_component/main_home/Guide";
-import Card from "./_component/main_home/Card";
 import ButtonBox from "./_component/main_home/ButtonBox";
 
 export default function Home() {
@@ -31,7 +30,6 @@ export default function Home() {
             <p>나에게 딱맞는 스터디 찾아요</p>
       </Guide>
       <hr />
-      <Card />
       <br />
       <ButtonBox />
       <hr />

--- a/src/app/search/_component/PopularKeyword.tsx
+++ b/src/app/search/_component/PopularKeyword.tsx
@@ -1,31 +1,37 @@
 import styles from "./popularKeyword.module.css";
+import { useState, useEffect } from "react";
+import GetPopularSearch from "@/app/api/popularSearch";
 
-const tags = ["카공", "취준", "영어공부", "영어", "루틴", "습관", "공부", "취준", "영어공부", "영어", "카공", "취준", "영어공부", "영어","Topcit"]
+interface SearchResult {
+    searchId: number;
+    keyword: string;
+    totalCount: number;
+}
 
 export default function PopularKeyword({slideNum} : {slideNum: 1 | 2 | 3}) {
 
-    const list1 :string[] = tags.slice( 0 , 6 );
-    const list2 :string[] = tags.slice( 6 , 12 );
-    const list3 :string[] = tags.slice( 12 , 18 );
+    const [ popularKeywords, setPopularKeyword ] = useState<string[] | null>(null);
 
+    useEffect(() => {
+        getPopular();
+    }, []);
+
+    const getPopular = async () => {
+        try {
+            const res = await GetPopularSearch();
+            const data: SearchResult[] = await res.data;
+            setPopularKeyword(data.map(item => item.keyword));
+            } catch (error) {
+            console.error(error);
+            }
+    };
 
     return(
         <div className={styles.container}>
-            {slideNum === 1 && (
-                list1.map((keyword, index) => (
-                    <p className={styles.keyword}>{`${index+1}. ${keyword}`}</p> 
-                )
-            ))}
-            {slideNum === 2 && (
-                list2.map((keyword, index) => (
-                    <p className={styles.keyword}>{`${index+7}. ${keyword}`}</p> 
-                )
-            ))}
-            {slideNum === 3 && (
-                list3.map((keyword, index) => (
-                    <p className={styles.keyword}>{`${index+13}. ${keyword}`}</p> 
-                ) 
-            ))}
+            {popularKeywords && 
+                popularKeywords.map((keyword, index) => (
+                    <p key={index} className={styles.keyword}>{`${index+1}. ${keyword}`}</p> 
+                ))}
         </div>
     );
 }

--- a/src/app/search/_component/SearchTag.tsx
+++ b/src/app/search/_component/SearchTag.tsx
@@ -2,21 +2,25 @@ import styles from "./searchTag.module.css";
 import IconX from "../../../../public/icons/search/Icon_X.svg";
 import Image from "next/image";
 
-export default function SearchTag({children}:{children:React.ReactNode}) {
-    const handeldelete = () => {
-    }
+interface IsearchTag {
+    isLogin?: boolean;
+    handleDelete: () => void;
+    children: React.ReactNode;
+}
+
+export default function SearchTag({handleDelete, children, isLogin}:IsearchTag) {
 
     return(
         <div className={styles.container}>
             <p className={styles.tag}>{children}</p>
-            <Image 
+            {isLogin && <Image 
                 src={IconX}
                 width={24}
                 height={24}
                 className={styles.icon}
                 alt="X"
-                onClick={handeldelete}
-            />
+                onClick={handleDelete}
+            />} 
         </div>
     );
 }

--- a/src/app/search/_component/searchTag.module.css
+++ b/src/app/search/_component/searchTag.module.css
@@ -4,7 +4,7 @@
     background-color: var(--gray-100);
     width: fit-content;
     height: 30px;
-    padding: 4px 8px 5px 16px;
+    padding: 3px 8px 2px 16px;
     border-radius: 4px;
     align-items: center;
     gap: 10px;

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -13,6 +13,10 @@ import "swiper/css";
 import "swiper/css/free-mode";
 import "swiper/css/pagination";
 import PopularKeyword from "./_component/PopularKeyword";
+import GetRecentSearch from "../api/recentSearch";
+import DeleteRecentSearch from "../api/deleteRecent";
+import { useEffect, useState } from "react";
+import useAuth from "@/hooks/useAuth";
 
 const shortCutIcons = [
     {
@@ -33,16 +37,60 @@ const shortCutIcons = [
     },
 ]
 
-const tags = ["카공", "취준", "영어공부", "영어", "루틴", "습관", "공부"]
-
 export default function Search() {
+    interface recent { keyword: string; };
+    const [recentKeywords, setRecentKeywords ] = useState<recent[]>([]);
+    const { accessToken, isLogin } = useAuth();
+
+    useEffect(() => {
+        if (isLogin) {
+            getRecent();
+        }else {
+            const recentNoLogin = sessionStorage.getItem('recentKeywords');
+            if ( recentNoLogin !== null){
+                const parsedRecent = JSON.parse(recentNoLogin);
+                setRecentKeywords(parsedRecent);
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!isLogin) {
+            sessionStorage.setItem('recentKeywords', JSON.stringify(recentKeywords));
+        }
+    }, [recentKeywords]);
+
+    const getRecent = async() => {
+        try{
+            const res = await GetRecentSearch(accessToken);
+            setRecentKeywords(res.data.map((item: {keyword:string}) => item.keyword));
+        }catch(error){
+            console.log(error);
+        }
+    };
+    
+    const handleEnter = (e:React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter" && !e.nativeEvent.isComposing){
+            const newValue = (e.target as HTMLInputElement).value;
+            setRecentKeywords([{ keyword: newValue }, ...recentKeywords]);
+        }
+    };
+
+    const handleDelete= async() => {
+        try {
+            const res = await DeleteRecentSearch(accessToken);
+        } catch(error){
+            console.log(error);
+        }
+    };
+
     return(
         <div className={styles.container}>
             <Navigation dark={true} onClick={()=>{return;}}>
                 <Image className={styles.iconBell} src={IconBell} width={58} height={58} alt="bell" />
             </Navigation>
             <div className={styles.searchInputBox}>
-                <Search_Input />
+                <Search_Input handleEnter={handleEnter}/>
             </div>
             <div className={styles.recentSearchBox}>
                 <div className={styles.recentBoxTop}>
@@ -55,9 +103,9 @@ export default function Search() {
                             slidesPerView={4}
                             spaceBetween={10}
                             >
-                            {tags.map((keyword, index) => (
+                            {recentKeywords.map((item, index) => (
                             <SwiperSlide className={styles.recentKeyword} key={index}>
-                                <SearchTag key={index}>{keyword}</SearchTag>
+                                <SearchTag isLogin={isLogin} handleDelete={handleDelete} key={index}>{item.keyword}</SearchTag>
                             </SwiperSlide>
                         ))}
                     </Swiper>
@@ -72,9 +120,6 @@ export default function Search() {
                         >
                     <SwiperSlide>
                         <PopularKeyword slideNum={1}/>
-                    </SwiperSlide>
-                    <SwiperSlide>
-                        <PopularKeyword slideNum={2}/>
                     </SwiperSlide>
                 </Swiper>
             </div>

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -27,9 +27,6 @@
     justify-content: space-between;
 }
 
-.subtitle {
-}
-
 .edit {
     color: var(--gray-600);
     cursor: pointer;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

search page에서 검색어 가져오는 부분까지 했습니다.

## 🧑‍💻 PR 세부 내용

인기 검색어 데이터 받아오기랑
최근 검색어도 비로그인 유저는 세션에 저장하도록 했고 
로그인 유저의 데이터 받아오기/삭제 기능까지 구현 했습니다.

검색 기능 구현 하는 중 get 메소드에서도 로그인 유저는 JWT가 필요해서 fetcher도 수정했습니다.

## 📸 스크린샷

<img width="202" alt="스크린샷 2024-05-14 오전 3 48 26" src="https://github.com/SWYP-LUCKY-SEVEN/front-end/assets/129826514/0d482c04-605e-4d7a-b070-0856eb4207fd">
