### PR TITLE
feat: 72시간 후 자동 신청거절, 스터디 타입에 따른 탭 자동 선택

### DIFF
--- a/src/app/_component/input/search_input.module.css
+++ b/src/app/_component/input/search_input.module.css
@@ -1,6 +1,8 @@
 .container {
   display: flex;
   flex-direction: column;
+  height: 40px;
+
 }
 
 .input {

--- a/src/app/search_result/searchResult.module.css
+++ b/src/app/search_result/searchResult.module.css
@@ -60,7 +60,7 @@
 .filterBox {
   display: flex;
   gap: 16px;
-  margin: 15px 30px 0 30px;
+  margin: 15px 30px 10px 30px;
 }
 
 .slideBox {
@@ -77,7 +77,7 @@
   display: flex;
   margin-left: 30px;
   margin-right: 30px;
-  margin-top: 30px;
+  margin-top: 10px;
   align-items: center;
   justify-content: space-between;
   font-size: 18px;

--- a/src/app/studyInfo/page.tsx
+++ b/src/app/studyInfo/page.tsx
@@ -24,6 +24,7 @@ import InfoAlertModal from "../_component/modal/infoAlertModal";
 import { useRouter } from "next/navigation";
 import useFromStore from "@/utils/from";
 import favoriteStudy from "../api/favoriteStudy";
+import useMemberStore from "../studyMember/store/useMemberStore";
 
 interface IFavStudy {
   id: number;
@@ -55,11 +56,11 @@ export default function StudyInfo() {
   const { accessToken, user } = useAuth();
   const [modalMsg, setModalMsg] = useState<string>("");
   const [join, setJoin] = useState<boolean>(false);
-  const [isQuick, setIsQuick] = useState<boolean>(false);
   const [isJoined, setIsJoined] = useState<boolean>(false);
   const [isOwner, setIsOwner] = useState<boolean>(false);
   const [isFav, setIsFav] = useState<boolean>(false);
   const [isRequestJoin, setIsRequestJoin] = useState<boolean>(false);
+  const { setStartDate, isQuick, setIsQuick } = useMemberStore();
   const [userProfile, setUserProfile] = useState<IUserProfileType>({
     email: "",
     nickname: "",
@@ -85,6 +86,7 @@ export default function StudyInfo() {
       console.log(studyId, data);
       setTendency(data.tendency);
       setDuration(data.duration);
+      setStartDate(data.start_date);
 
       if (data.matching_type === "Quick") {
         setIsQuick(true);

--- a/src/app/studyList/studyList.module.css
+++ b/src/app/studyList/studyList.module.css
@@ -54,7 +54,7 @@
 .filterBox {
   display: flex;
   gap: 16px;
-  margin: 15px 30px 0 30px;
+  margin: 15px 30px 10px 30px;
 }
 
 .slideBox {
@@ -71,7 +71,7 @@
   display: flex;
   margin-left: 30px;
   margin-right: 30px;
-  margin-top: 30px;
+  margin-top: 20px;
   align-items: center;
   justify-content: space-between;
   font-size: 18px;

--- a/src/app/studyMember/_component/memberCard.tsx
+++ b/src/app/studyMember/_component/memberCard.tsx
@@ -24,6 +24,7 @@ export default function MemberCard({isDeclined, isAccepted,isRequesting, isReque
     const formattedReqDate = moment(requestData?.request_date).format("MM-DD HH:MM");
     const [hoursRemaining, setHoursRemaining] = useState<number | null>(null);
     const requestTime = moment(requestData?.request_date);
+    const nowTime = moment();
     const [secondsRemaining, setSecondsRemaining] = useState<number>(0);
     const [ src, setSrc ] = useState<string>(Icon);
 
@@ -37,7 +38,6 @@ export default function MemberCard({isDeclined, isAccepted,isRequesting, isReque
 
     useEffect(() => {
         if (isRequest && requestData?.request_date) {
-            const nowTime = moment();
             const duration = moment.duration(requestTime.add(72, 'hours').diff(nowTime));
             const hours = duration.asHours();
             setHoursRemaining(hours > 0 ? Math.ceil(hours) : 0);

--- a/src/app/studyMember/_component/memberCard.tsx
+++ b/src/app/studyMember/_component/memberCard.tsx
@@ -23,6 +23,7 @@ export default function MemberCard({isDeclined, isAccepted,isRequesting, isReque
     const formattedDate =  moment(memberData?.join_date).format("MM-DD HH:MM");
     const formattedReqDate = moment(requestData?.request_date).format("MM-DD HH:MM");
     const [hoursRemaining, setHoursRemaining] = useState<number | null>(null);
+    const requestTime = moment(requestData?.request_date);
     const [secondsRemaining, setSecondsRemaining] = useState<number>(0);
     const [ src, setSrc ] = useState<string>(Icon);
 
@@ -36,16 +37,16 @@ export default function MemberCard({isDeclined, isAccepted,isRequesting, isReque
 
     useEffect(() => {
         if (isRequest && requestData?.request_date) {
-            const requestTime = moment(requestData.request_date);
             const nowTime = moment();
             const duration = moment.duration(requestTime.add(72, 'hours').diff(nowTime));
-            const seconds = duration.asSeconds();
-            setSecondsRemaining(seconds > 0 ? Math.ceil(seconds) : 0);
+            const hours = duration.asHours();
+            setHoursRemaining(hours > 0 ? Math.ceil(hours) : 0);
         }
+    });
+
+    useEffect(() =>{
         const interval = setInterval(() => {
             if (isRequest && requestData?.request_date) {
-                const requestTime = moment(requestData.request_date);
-                const nowTime = moment();
                 const duration = moment.duration(requestTime.add(72, 'hours').diff(nowTime));
                 const seconds = duration.asSeconds();
                 setSecondsRemaining(seconds > 0 ? Math.ceil(seconds) : 0);

--- a/src/app/studyMember/_component/memberCard.tsx
+++ b/src/app/studyMember/_component/memberCard.tsx
@@ -22,8 +22,8 @@ export default function MemberCard({isDeclined, isAccepted,isRequesting, isReque
     memberData, requestData, handleOutMember, handleAcceptRequest, handleDeclineRequest}: IMemberCard) {
     const formattedDate =  moment(memberData?.join_date).format("MM-DD HH:MM");
     const formattedReqDate = moment(requestData?.request_date).format("MM-DD HH:MM");
-    const nowTime = moment().format('YYYY-MM-DD HH:mm:ss');
     const [hoursRemaining, setHoursRemaining] = useState<number | null>(null);
+    const [secondsRemaining, setSecondsRemaining] = useState<number>(0);
     const [ src, setSrc ] = useState<string>(Icon);
 
     useEffect(() => {
@@ -35,19 +35,27 @@ export default function MemberCard({isDeclined, isAccepted,isRequesting, isReque
     });
 
     useEffect(() => {
-        if (isRequest) {
-            setSrc(requestData?.profile_image ?? Icon);
-        } else {
-            setSrc(memberData?.profile_image ?? Icon);
-        }
-
-        if (requestData?.request_date) {
+        if (isRequest && requestData?.request_date) {
             const requestTime = moment(requestData.request_date);
             const nowTime = moment();
             const duration = moment.duration(requestTime.add(72, 'hours').diff(nowTime));
-            const hours = duration.asHours();
-            setHoursRemaining(hours > 0 ? Math.ceil(hours) : 0);
+            const seconds = duration.asSeconds();
+            setSecondsRemaining(seconds > 0 ? Math.ceil(seconds) : 0);
         }
+        const interval = setInterval(() => {
+            if (isRequest && requestData?.request_date) {
+                const requestTime = moment(requestData.request_date);
+                const nowTime = moment();
+                const duration = moment.duration(requestTime.add(72, 'hours').diff(nowTime));
+                const seconds = duration.asSeconds();
+                setSecondsRemaining(seconds > 0 ? Math.ceil(seconds) : 0);
+
+                if (seconds <= 0) {
+                    handleDeclineRequest && handleDeclineRequest();
+                }
+            }
+        }, 1000);
+        return () => clearInterval(interval);
     }, [isRequest, requestData, memberData]);
 
     return(

--- a/src/app/studyMember/page.tsx
+++ b/src/app/studyMember/page.tsx
@@ -39,10 +39,12 @@ export default function studyMember() {
     useEffect(() => {
     if (startDate && !isQuick && moment(startDate).isSameOrAfter(moment(), "day")) {
         setIsJoinRequest(true);
+        getRequestMembers();
     } else {
         setIsJoinMember(true);
+        getStudyMembers();
     }
-    }, [startDate]);
+    },[]);
 
     const getRequestMembers = async() => {
         try{

--- a/src/app/studyMember/page.tsx
+++ b/src/app/studyMember/page.tsx
@@ -135,7 +135,7 @@ export default function studyMember() {
 
     return(
         <div className={styles.container}>
-            <Navigation isBack={true} dark={false} onClick={()=>{return}}>쇼터디 멤버 관리</Navigation>
+            <Navigation isBack={true} dark={false} onClick={() => router.back()}>쇼터디 멤버 관리</Navigation>
             <div className={styles.hr}></div>
             <div className={styles.contentContainer}>
                 <div className={styles.btnBox}>

--- a/src/app/studyMember/page.tsx
+++ b/src/app/studyMember/page.tsx
@@ -19,6 +19,7 @@ import AlertModal from "../_component/modal/alertModal";
 import { useRouter } from "next/navigation";
 import AcceptJoinStudy from "../api/acceptJoinRequest";
 import DeclineJoinStudy from "../api/declineJoinRequest";
+import moment from "moment";
 
 export default function studyMember() {
     const {accessToken} = useAuth();
@@ -32,7 +33,16 @@ export default function studyMember() {
     const [ JoinRequests, setJoinRequests ] = useState<IRequestMember[]>([]);
     const { openModal:openOutModal, handleOpenModal:handleOpenOutModal, handleCloseModal:handleCloseOutModal } =  useModal();
     const { openModal:openAlertModal, handleOpenModal:handleOpenAlertModal, handleCloseModal:handleCloseAlertModal } =  useModal();
-    const { outMemberName, setOutMemberName, outUserId, setOutUserId, exitReasons, reqUserId, setReqUserId } = useMemberStore();
+    const { outMemberName, setOutMemberName, outUserId, setOutUserId, exitReasons, reqUserId, setReqUserId, startDate, isQuick } = useMemberStore();
+    const [ selectedTab, setSelectedTab ] = useState<string>("");
+
+    useEffect(() => {
+    if (startDate && !isQuick && moment(startDate).isSameOrAfter(moment(), "day")) {
+        setIsJoinRequest(true);
+    } else {
+        setIsJoinMember(true);
+    }
+    }, [startDate]);
 
     const getRequestMembers = async() => {
         try{
@@ -104,6 +114,7 @@ export default function studyMember() {
         console.log("out");
         outStudyMember();
         handleOpenAlertModal();
+        router.push(`/studyInfo?studyId=${studyId}`);
     };
 
     const handleOk = () => {

--- a/src/app/studyMember/store/useMemberStore.tsx
+++ b/src/app/studyMember/store/useMemberStore.tsx
@@ -9,6 +9,10 @@ interface IMemberStore {
     setReqUserId: (id: number) => void;
     exitReasons: string[];
     setExitReasons: (reasons: string[]) => void;
+    startDate: string;
+    setStartDate: (date: string) => void;
+    isQuick: boolean;
+    setIsQuick: (quick: boolean) => void;
 }
 
 const useMemberStore = create<IMemberStore>((set) => ({
@@ -20,6 +24,10 @@ const useMemberStore = create<IMemberStore>((set) => ({
     setReqUserId: (id: number) => set({ reqUserId: id }),
     exitReasons: [],
     setExitReasons: (reasons: string[]) => set({ exitReasons: reasons }),
+    startDate: "",
+    setStartDate: (date:string) => set({ startDate: date}),
+    isQuick: false,
+    setIsQuick: (quick: boolean) => set({ isQuick: quick }),
 }));
 
 export default useMemberStore;

--- a/src/app/studySetting/page.tsx
+++ b/src/app/studySetting/page.tsx
@@ -70,7 +70,7 @@ export default function StudySetting() {
           </p>
           <p className={styles.menu} onClick={() => router.push(`/studyMember?studyId=${studyId}`)}>
             멤버관리
-            {membersCount ? <div className={styles.count}>{membersCount}+</div> : null}
+            {membersCount ? <div className={styles.count}>{membersCount}{membersCount >= 10 ? "+" : null}</div> : null}
             <Image className={styles.icon} src={Icon} width={16} height={16} alt="arrow" />
           </p>
           <p className={styles.menu} onClick={handleOpenModal}>

--- a/src/app/studySetting/page.tsx
+++ b/src/app/studySetting/page.tsx
@@ -70,7 +70,7 @@ export default function StudySetting() {
           </p>
           <p className={styles.menu} onClick={() => router.push(`/studyMember?studyId=${studyId}`)}>
             멤버관리
-            <div className={styles.count}>{membersCount}+</div>
+            {membersCount ? <div className={styles.count}>{membersCount}+</div> : null}
             <Image className={styles.icon} src={Icon} width={16} height={16} alt="arrow" />
           </p>
           <p className={styles.menu} onClick={handleOpenModal}>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

스터디 멤버 관리 부분 기능 추가하였습니다.

## 🧑‍💻 PR 세부 내용

스터디 가입 요청 72시간후 자동 거절되도록 설정해놨는데 이건 테스트를 해봐야할 것 같고
스터디 타입에 따라 멤버 관리 들어갔을 때 디폴트로 보여지는 탭 설정했습니다

## 📸 스크린샷

스크린샷을 첨부해주세요.
