### PR TITLE
fix: 스터디 상세 페이지에서 나간 멤버 제외

### DIFF
--- a/src/app/studyInfo/_component/MemberCard.tsx
+++ b/src/app/studyInfo/_component/MemberCard.tsx
@@ -4,20 +4,18 @@ import Badge_owner from "../../../../public/icons/studyInfo/badge_owner.svg";
 import Icon from "../../../../public/icons/studyInfo/Ellipse 230.svg";
 
 interface IMemberCard {
-    nickname: string;
-    profile: string;
-    owner?: boolean;
+    member: Imember;
     onClick: (nickname: string) => void;
 }
 
-export default function MemberCard({nickname, profile=Icon, owner=false, onClick}: IMemberCard){
+export default function MemberCard({member, onClick}: IMemberCard){
     return(
-        <div className={styles.container} onClick={() => onClick(nickname)}>
+        <div className={styles.container} onClick={() => onClick(member.nickname)}>
             <div className={styles.imageBox}>
-                <Image className={styles.profileImage} src={profile} width={88} height={88} alt="image" />
+                <Image className={styles.profileImage} src={member.profileImage} width={88} height={88} alt="image" />
             </div>
-            {owner && <Image className={styles.badge} src={Badge_owner} width={32} height={32} alt="owner" />}
-            <p className={styles.nickname}>{nickname}</p>
+            {member._owner && <Image className={styles.badge} src={Badge_owner} width={32} height={32} alt="owner" />}
+            <p className={styles.nickname}>{member.nickname}</p>
         </div>
     )
 }

--- a/src/app/studyInfo/page.tsx
+++ b/src/app/studyInfo/page.tsx
@@ -39,12 +39,6 @@ interface IFavStudy {
   additionalInfos: string[];
 }
 
-interface Imember {
-  nickname: string;
-  profileImage: string;
-  _owner: boolean;
-}
-
 export default function StudyInfo() {
   const router = useRouter();
   const { openModal, handleOpenModal, handleCloseModal } = useModal();
@@ -250,13 +244,12 @@ export default function StudyInfo() {
             <p className={styles.subTitle}>참여 멤버</p>
             <div className={styles.members}>
               {data.membersList.map((member: Imember, index: number) => (
-                <MemberCard
-                  key={index}
-                  nickname={member.nickname}
-                  profile={member.profileImage}
-                  owner={member._owner}
-                  onClick={() => setWatchMember(member.nickname)}
-                />
+                member.exit_status === "None" && (
+                  <MemberCard
+                    key={index}
+                    member= {member}
+                    onClick={() => setWatchMember(member.nickname)}
+                  />)
               ))}
             </div>
           </div>

--- a/src/app/studyInfo/type/IProfileType.ts
+++ b/src/app/studyInfo/type/IProfileType.ts
@@ -10,3 +10,10 @@ interface IUserStudyType {
     in_complete: number;
     in_progress: number;
 }
+
+interface Imember {
+    nickname: string;
+    profileImage: string;
+    _owner: boolean;
+    exit_status: string;
+}

--- a/src/app/studyMember/_component/memberCard.module.css
+++ b/src/app/studyMember/_component/memberCard.module.css
@@ -28,6 +28,10 @@
     cursor: pointer;
 }
 
+.img {
+    border-radius: 50%;
+}
+
 .rightBox {
     width: 100%;
     display: flex;

--- a/src/app/studyMember/_component/memberCard.tsx
+++ b/src/app/studyMember/_component/memberCard.tsx
@@ -66,7 +66,7 @@ export default function MemberCard({isDeclined, isAccepted,isRequesting, isReque
     return(
         <div className={isRequesting? styles.container : styles.done}>
             <div className={styles.imgContainer} onClick={() => onClick(nickname)}>
-                <Image src={src} onClick={()=>{}} width={80} height={80} alt="ProfileImage" />
+                <Image className={styles.img} src={src} onClick={()=>{}} width={80} height={80} alt="ProfileImage" />
             </div>
             <div className={styles.rightBox}>
                 {isRequest ? <p className={styles.nickname}>{requestData?.nickname}님이 함께하길 원하고 있어요</p>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

스터디 상세 페이지에서 나간 멤버는 나타나지 않도록 변경했습니다.

## 🧑‍💻 PR 세부 내용

나간 멤버에게 버튼이 어떻게 보여질지는 전달 받는대로 ui 쪽도 처리 할 예정입니다.
멤버 관리 부분 프로필이 사각형도 그대로 보여지길래 그 부분도 수정했습니당

## 📸 스크린샷

스크린샷을 첨부해주세요.
