### PR TITLE
fix: 자동거절시 거절기록 남기기, 강퇴 이유 초기화

### DIFF
--- a/src/app/studySetting/studyMember/_component/memberCard.tsx
+++ b/src/app/studySetting/studyMember/_component/memberCard.tsx
@@ -39,7 +39,7 @@ export default function MemberCard({
   const nowTime = moment();
   const [src, setSrc] = useState<string>(Icon);
   const [nickname, setNickname] = useState<string>("");
-  const [declined, setDeclined] = useState<boolean>(isDeclined ?? false);
+  const [autoDeclined, setAutoDeclined] = useState<boolean>(false);
 
   useEffect(() => {
     if (isRequest) {
@@ -52,21 +52,13 @@ export default function MemberCard({
   });
 
   useEffect(() => {
-    if (isRequest && requestData?.request_date) {
-      const duration = moment.duration(requestTime.add(72, "hours").diff(nowTime));
-      const hours = duration.asHours();
-      setHoursRemaining(hours > 0 ? Math.ceil(hours) : 0);
-    }
-  });
-
-  useEffect(() => {
     const interval = setInterval(() => {
       if (isRequest && requestData?.request_date) {
         const duration = moment.duration(requestTime.add(72, "hours").diff(nowTime));
         const secondsRemaining = duration.asSeconds();
 
         if (secondsRemaining <= 0) {
-            setDeclined(true);
+            setAutoDeclined(true);
             handleDeclineRequest && handleDeclineRequest();
         }
       }
@@ -93,9 +85,14 @@ export default function MemberCard({
               수락완료
             </Button>
           )}
-          {isRequest && declined && (
+          {isRequest && isDeclined && (
             <Button size="very_small" property="disabled">
               거절완료
+            </Button>
+          )}
+          {isRequest && autoDeclined && (
+            <Button size="very_small" property="disabled">
+              자동거절
             </Button>
           )}
           {isMember && (

--- a/src/app/studySetting/studyMember/_component/memberCard.tsx
+++ b/src/app/studySetting/studyMember/_component/memberCard.tsx
@@ -37,9 +37,9 @@ export default function MemberCard({
   const [hoursRemaining, setHoursRemaining] = useState<number | null>(null);
   const requestTime = moment(requestData?.request_date);
   const nowTime = moment();
-  const [secondsRemaining, setSecondsRemaining] = useState<number>(0);
   const [src, setSrc] = useState<string>(Icon);
   const [nickname, setNickname] = useState<string>("");
+  const [declined, setDeclined] = useState<boolean>(isDeclined ?? false);
 
   useEffect(() => {
     if (isRequest) {
@@ -63,11 +63,11 @@ export default function MemberCard({
     const interval = setInterval(() => {
       if (isRequest && requestData?.request_date) {
         const duration = moment.duration(requestTime.add(72, "hours").diff(nowTime));
-        const seconds = duration.asSeconds();
-        setSecondsRemaining(seconds > 0 ? Math.ceil(seconds) : 0);
+        const secondsRemaining = duration.asSeconds();
 
-        if (seconds <= 0) {
-          handleDeclineRequest && handleDeclineRequest();
+        if (secondsRemaining <= 0) {
+            setDeclined(true);
+            handleDeclineRequest && handleDeclineRequest();
         }
       }
     }, 1000);
@@ -93,7 +93,7 @@ export default function MemberCard({
               수락완료
             </Button>
           )}
-          {isRequest && isDeclined && (
+          {isRequest && declined && (
             <Button size="very_small" property="disabled">
               거절완료
             </Button>

--- a/src/app/studySetting/studyMember/page.tsx
+++ b/src/app/studySetting/studyMember/page.tsx
@@ -62,6 +62,7 @@ export default function studyMember() {
     outUserId,
     setOutUserId,
     exitReasons,
+    setExitReasons,
     setAcceptUserId,
     setDeclineUserId,
     acceptUserId,
@@ -81,7 +82,6 @@ export default function studyMember() {
   });
 
   useEffect(() => {
-    console.log("rerender", studyId);
     if (!isQuick && moment(startDate).isSameOrAfter(moment(), "day")) {
       setIsJoinRequest(true);
     } else {
@@ -189,6 +189,7 @@ export default function studyMember() {
 
   const handleOk = () => {
     handleCloseAlertModal();
+    setExitReasons([]);
   };
 
   const handleAcceptRequest = (member: IRequestMember) => {


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

자동거절시 거절기록 남기기, 강퇴 이유 초기화

## 🧑‍💻 PR 세부 내용

72시간 후 자동거절이 되면 거절 완료 기록이 안 남아서 수정했습니다.
자동거절이라고 표시되도록 해뒀어요.

그리고 강퇴를 연달아서 하면 이전에 선택했던 퇴장 이유가 남아있던 부분도 수정했습니다!

## 📸 스크린샷

스크린샷을 첨부해주세요.
