### PR TITLE
Feat/No login

### DIFF
--- a/src/app/_component/noStudy/NoStudy.tsx
+++ b/src/app/_component/noStudy/NoStudy.tsx
@@ -1,18 +1,28 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./noStudy.module.css";
 import Image from "next/image";
 import Icon from "../../../../public/icons/studyList/Mark_warning.svg";
 
 interface NoStudyProps {
   children?: React.ReactNode;
+  type?: "NoStudy" | "NoLogin";
 }
 
-export default function NoStudy({ children }: NoStudyProps) {
+export default function NoStudy({ children, type="NoStudy" }: NoStudyProps) {
+  const [content, setContent] = useState<string>("");
+
+  useEffect(() => {
+    if(type === "NoStudy")
+      setContent("직접 스터디를 등록해 보세요!");
+    if(type === "NoLogin")
+      setContent("로그인이 필요한 서비스예요.");
+  }, []);
+
   return (
     <div className={styles.container}>
       <Image className={styles.icon} src={Icon} alt="noStudy" width={110} height={110} />
       {children && <p className={styles.contentTop}>{children}</p>}
-      <p className={styles.contentBtm}>직접 스터디를 등록해 보세요!</p>
+      <p className={styles.contentBtm}>{content}</p>
     </div>
   );
 }

--- a/src/app/_component/ratingBox/RatingBox.tsx
+++ b/src/app/_component/ratingBox/RatingBox.tsx
@@ -10,13 +10,10 @@ import Iconc from "../../../../public/icons/studyInfo/Icon_grade_C.svg";
 interface IRatingBox {
     user: IUserProfileType;
     type?: "modal" | "myPage";
+    isLogin?: boolean;
 }
 
-const Icons = [
-
-]
-
-export default function RatingBox({user, type="modal"}:IRatingBox) {
+export default function RatingBox({user, type="modal", isLogin=true}:IRatingBox) {
     const [ score, setScore ] = useState<number>(0);
     const [ src, setSrc ] = useState<string>(IconA);
 
@@ -29,11 +26,11 @@ export default function RatingBox({user, type="modal"}:IRatingBox) {
         }else if( score >=20 && score <= 40){
             setSrc(Iconc)
         }
-
     }, []);
 
     return(
         <div className={type === "modal" ? styles.container : styles.containerMy}>
+            {isLogin ?
             <div className={styles.ratingBox}>
                 <div className={styles.containerTop}>
                     <p className={styles.title}>쇼터디 성적표</p>
@@ -60,6 +57,8 @@ export default function RatingBox({user, type="modal"}:IRatingBox) {
                     />
                 </div>
             </div>
+            : <p className={styles.NoLogin}>로그인하고, 나의 쇼터디 성적표를 확인하세요!</p>
+            }
         </div>
     );
 }

--- a/src/app/_component/ratingBox/ratingBox.module.css
+++ b/src/app/_component/ratingBox/ratingBox.module.css
@@ -11,6 +11,9 @@
   height: 106px;
   background-color: var(--gray-800);
   color: var(--gray-50);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .ratingBox {
@@ -34,13 +37,14 @@
   gap: 10px;
 }
 
-.scoreIcon {
-}
-
 .score {
   font-size: 20px;
 }
 
 .progressBarBox {
   margin-top: 15px;
+}
+
+.NoLogin {
+  color: var(--gray-50);
 }

--- a/src/app/_component/ratingBox/ratingBox.module.css
+++ b/src/app/_component/ratingBox/ratingBox.module.css
@@ -18,6 +18,7 @@
 
 .ratingBox {
   padding: 10px 30px 10px 30px;
+  width: 100%;
 }
 
 .containerTop {

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -17,12 +17,14 @@ import NoStudy from "../_component/noStudy/NoStudy";
 import getFilter from "../api/getFilter";
 import Navigation from "../_component/navigation/page";
 import Loading from "../_component/Loading";
+import useAuth from "@/hooks/useAuth";
 
 export default function Main_home() {
   const [isLoading, setLoading] = useState<boolean>(true);
   const [postData, setPostData] = useState<IfilterType[]>([]);
   const { setFrom } = useFromStore();
   const router = useRouter();
+  const {isLogin} = useAuth();
 
   useEffect(() => {
     setFrom("home");
@@ -42,9 +44,8 @@ export default function Main_home() {
     };
 
     const timer = setTimeout(getPopular, 700);
-
     return () => clearTimeout(timer);
-  }, []);
+    }, []);
 
   return (
     <>
@@ -71,7 +72,9 @@ export default function Main_home() {
                 size="medium"
                 property="confirm"
                 onClick={() => {
-                  router.push("./fastMatching");
+                  isLogin ?
+                  router.push("./fastMatching")
+                  :router.push("./login")
                 }}
               >
                 빠른 매칭
@@ -80,7 +83,9 @@ export default function Main_home() {
                 size="medium"
                 property="confirm"
                 onClick={() => {
-                  router.push("./createStudy");
+                  isLogin ?
+                  router.push("./createStudy")
+                  :router.push("./login")
                 }}
               >
                 쇼터디 운영

--- a/src/app/myStudy/mystudy.module.css
+++ b/src/app/myStudy/mystudy.module.css
@@ -16,6 +16,10 @@
   bottom: 0;
 }
 
+.noStudyBox {
+
+}
+
 .Header {
   margin-left: 38px;
   margin-top: 16px;
@@ -143,7 +147,10 @@
 
 .NoContainer {
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
+  margin-top: 50px;
 }
 
 .NoStudyBtn {

--- a/src/app/myStudy/page.tsx
+++ b/src/app/myStudy/page.tsx
@@ -17,7 +17,7 @@ import Loading from "../_component/Loading";
 
 export default function MyStudy() {
   const router = useRouter();
-  const { accessToken } = useAuth();
+  const { accessToken, isLogin } = useAuth();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [studyData, setStudyData] = useState<IMyStudyType[]>([]);
   const [progress, setProgress] = useState<number>(0);
@@ -50,10 +50,6 @@ export default function MyStudy() {
     router.push(`./studyInfo?studyId=${page}`);
   };
 
-  const handleGoList = () => {
-    router.push("./studyList");
-  };
-
   return (
     <>
       {isLoading ? (
@@ -64,17 +60,24 @@ export default function MyStudy() {
             <Navigation dark={true} onClick={() => {}}>
               <Image className={styles.iconBell} src={IconBell} width={48} height={48} alt="bell" />
             </Navigation>
-            <p className={styles.Header}>총 {studyData.length}개의 쇼터디에 참여중이에요!</p>
-            {studyData.length === 0 ? (
-              <>
-                <NoStudy>참여중인 쇼터디가 없어요</NoStudy>
+            {studyData.length === 0 && isLogin? (
                 <div className={styles.NoContainer}>
-                  <div className={styles.NoStudyBtn} onClick={handleGoList}>
+                <NoStudy>참여중인 쇼터디가 없어요</NoStudy>
+                  <div className={styles.NoStudyBtn} onClick={() => router.push("./studyList")}>
                     쇼터디 둘러보기
                   </div>
                 </div>
-              </>
-            ) : (
+            ) :
+            isLogin === false ? (
+              <div className={styles.NoContainer}>
+              <NoStudy type="NoLogin">로그인이 필요해요</NoStudy>
+              <div className={styles.NoStudyBtn} onClick={() => router.push("./login")}>
+                로그인 / 회원가입
+              </div>
+          </div>
+            )
+            : (<>
+              <p className={styles.Header}>총 {studyData.length}개의 쇼터디에 참여중이에요!</p>
               <div className={styles.CardBox}>
                 {studyData.map((data, index) => (
                   <div
@@ -120,7 +123,7 @@ export default function MyStudy() {
                   </div>
                 ))}
               </div>
-            )}
+              </>)}
           </div>
           <div className={styles.FooterContainer}>
             <Footer selectedIndex={2} />

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -50,12 +50,9 @@ export default function Profile() {
 
   useEffect(() => {
     setFrom("profile");
-    
-  }, []);
 
-  useEffect(() => {
     if (profileData) {
-      console.log(myProfileData);
+      console.log(profileData);
       setMyProfileData(profileData.profile);
       setProfileStudyMenu(profileMenuLabeling(profileData.study_count));
     } else {
@@ -68,7 +65,7 @@ export default function Profile() {
           user_id: -1,
       })
     }
-  }, [accessToken]);
+  }, []);
 
   const keyLabels = {
     in_favorite: "찜한 스터디",
@@ -84,8 +81,6 @@ export default function Profile() {
         data[key],
     }));
   };
-
-  
 
   return (
     <>
@@ -123,7 +118,6 @@ export default function Profile() {
                 {myProfileData && <RatingBox user={myProfileData} type="myPage" isLogin={isLogin}/>}
               </div>
             </div>
-
             <div className={styles.ProfileMenuBox}>
               {profileStudyMenu &&
                 profileStudyMenu?.map((menu, idx: number) => {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -50,6 +50,7 @@ export default function Profile() {
 
   useEffect(() => {
     setFrom("profile");
+    
   }, []);
 
   useEffect(() => {

--- a/src/app/profile/profile.module.css
+++ b/src/app/profile/profile.module.css
@@ -28,10 +28,23 @@
   gap: 5px;
 }
 
-.nickname {
+.Nickname {
   font-size: 16px;
   line-height: 26.88px;
   color: var(--gray-800);
+}
+
+.noLoginName {
+  font-size: 16px;
+  line-height: 26.88px;
+  color: var(--gray-800);
+  cursor: pointer;
+}
+
+.noLoginSub {
+  font-size: 16px;
+  color: var(--gray-400);
+  line-height: 26.88px;
 }
 
 .editProfile {

--- a/src/app/studyInfo/type/IProfileType.ts
+++ b/src/app/studyInfo/type/IProfileType.ts
@@ -1,5 +1,5 @@
 interface IUserProfileType {
-    email: string;
+    email: string | null;
     nickname: string;
     profile_img: string;
     rating: number | null;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

비로그인 유저에게 보여지는 화면 구현

## 🧑‍💻 PR 세부 내용

마이페이지 리액트 쿼리로 리팩토링 & 비로그인 화면 구현
홈에서 빠른 매칭, 쇼터디 입장 눌렀을 시 로그인 화면으로 이동,
나의 스터디 화면에
미로그인 진입 시 보여지는 화면 설정해뒀고,
NoStudy 컴포넌트에 재사용성을 높이기 위한 type 프로퍼티 추가했습니다.

일단 비로그인 화면 디자인이 없어서 임의로 해뒀습니다.
그리고 로그인 후 마이페이지 첫 진입시 데이터가 ui에 안 보여서 이 부분은 수정을 해야할 것 같아요ㅜ.ㅜ
두번째 진입시부터 보이네요

## 📸 스크린샷

<img width="454" alt="스크린샷 2024-06-05 오후 2 52 44" src="https://github.com/SWYP-LUCKY-SEVEN/front-end/assets/129826514/335d7cc0-450d-4f8f-bd92-63f438df84ef">
<img width="441" alt="스크린샷 2024-06-05 오후 2 52 53" src="https://github.com/SWYP-LUCKY-SEVEN/front-end/assets/129826514/2ccf63dd-7d3c-40bf-b48b-d7a1dde1ae4a">
